### PR TITLE
Support new tracking script and more options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Nuxt Fathom
 
 Implement Fathom analytics in your Nuxt app.
@@ -8,7 +7,9 @@ Implement Fathom analytics in your Nuxt app.
 ```
 $ npm i @yabhq/nuxt-fathom
 ```
-In your **nuxt.config.js**:
+
+Configure the module in your **nuxt.config.js**:
+
 ```JavaScript
 modules: [
     // ....
@@ -19,10 +20,10 @@ modules: [
         auto: true, // optional, defaults to `true` (automatically track page views)
         canonical: true, // optional, defaults to `true`
         excludedDomains: 'example.com,localhost', // optional, defaults to ''
-        includedDomains: 'example.com,localhost', // optional, defaults to ''
-        spa: 'auto', // optional, defaults to 'auto'. https://usefathom.com/support/tracking
-        scriptSrc: 'https://bluedonkey.example.com/script.js', // optional, defaults to 'https://cdn.usefathom.com/tracker.js'. https://usefathom.com/support/custom-domains
         honorDoNotTrack: false, // optional, defaults to `false`
+        includedDomains: 'example.com,localhost', // optional, defaults to ''
+        scriptSrc: 'https://bluedonkey.example.com/script.js', // optional, defaults to 'https://cdn.usefathom.com/tracker.js'. See here for details: https://usefathom.com/support/custom-domains
+        spa: 'auto', // optional, defaults to 'auto'
     }],
     // ....
 ]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ modules: [
 
         // Advanced configuration. See here for details: https://usefathom.com/support/tracking-advanced
         auto: true, // optional, defaults to `true` (automatically track page views)
+        canonical: true, // optional, defaults to `true`
         spa: 'pushstate', // optional, defaults to 'pushstate'. https://usefathom.com/support/tracking
         scriptSrc: 'https://bluedonkey.example.com/script.js', // optional, defaults to 'https://cdn.usefathom.com/tracker.js'. https://usefathom.com/support/custom-domains
         honorDoNotTrack: false, // optional, defaults to `false`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Implement Fathom analytics in your Nuxt app.
 
 ## Quick Install
 
-
 ```
 $ npm i @yabhq/nuxt-fathom
 ```
@@ -15,7 +14,8 @@ modules: [
     // ....
     ['@yabhq/nuxt-fathom', {
         siteId: 'XXXXXX', // required
-        spa: 'pushstate' // optional, default to pushstate. https://usefathom.com/support/tracking
+        spa: 'pushstate' // optional, defaults to pushstate. https://usefathom.com/support/tracking
+        scriptSrc: 'https://bluedonkey.example.com/script.js', // optional, defaults to `https://cdn.usefathom.com/tracker.js`. https://usefathom.com/support/custom-domains
     }],
     // ....
 ]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ modules: [
         // Advanced configuration. See here for details: https://usefathom.com/support/tracking-advanced
         auto: true, // optional, defaults to `true` (automatically track page views)
         canonical: true, // optional, defaults to `true`
+        excludedDomains: 'example.com,localhost', // optional, defaults to ''
+        includedDomains: 'example.com,localhost', // optional, defaults to ''
         spa: 'pushstate', // optional, defaults to 'pushstate'. https://usefathom.com/support/tracking
         scriptSrc: 'https://bluedonkey.example.com/script.js', // optional, defaults to 'https://cdn.usefathom.com/tracker.js'. https://usefathom.com/support/custom-domains
         honorDoNotTrack: false, // optional, defaults to `false`

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ modules: [
         siteId: 'XXXXXX', // required
 
         // Advanced configuration. See here for details: https://usefathom.com/support/tracking-advanced
-        spa: 'pushstate' // optional, defaults to pushstate. https://usefathom.com/support/tracking
-        scriptSrc: 'https://bluedonkey.example.com/script.js', // optional, defaults to `https://cdn.usefathom.com/tracker.js`. https://usefathom.com/support/custom-domains
+        auto: true, // optional, defaults to `true` (automatically track page views)
+        spa: 'pushstate', // optional, defaults to 'pushstate'. https://usefathom.com/support/tracking
+        scriptSrc: 'https://bluedonkey.example.com/script.js', // optional, defaults to 'https://cdn.usefathom.com/tracker.js'. https://usefathom.com/support/custom-domains
         honorDoNotTrack: false, // optional, defaults to `false`
     }],
     // ....

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ modules: [
         canonical: true, // optional, defaults to `true`
         excludedDomains: 'example.com,localhost', // optional, defaults to ''
         includedDomains: 'example.com,localhost', // optional, defaults to ''
-        spa: 'pushstate', // optional, defaults to 'pushstate'. https://usefathom.com/support/tracking
+        spa: 'auto', // optional, defaults to 'auto'. https://usefathom.com/support/tracking
         scriptSrc: 'https://bluedonkey.example.com/script.js', // optional, defaults to 'https://cdn.usefathom.com/tracker.js'. https://usefathom.com/support/custom-domains
         honorDoNotTrack: false, // optional, defaults to `false`
     }],

--- a/README.md
+++ b/README.md
@@ -16,14 +16,30 @@ modules: [
     ['@yabhq/nuxt-fathom', {
         siteId: 'XXXXXX', // required
 
-        // Advanced configuration. See here for details: https://usefathom.com/support/tracking-advanced
-        auto: true, // optional, defaults to `true` (automatically track page views)
-        canonical: true, // optional, defaults to `true`
-        excludedDomains: 'example.com,localhost', // optional, defaults to ''
-        honorDoNotTrack: false, // optional, defaults to `false`
-        includedDomains: 'example.com,localhost', // optional, defaults to ''
-        scriptSrc: 'https://bluedonkey.example.com/script.js', // optional, defaults to 'https://cdn.usefathom.com/tracker.js'. See here for details: https://usefathom.com/support/custom-domains
-        spa: 'auto', // optional, defaults to 'auto'
+        // Advanced configuration
+        // See here for details: https://usefathom.com/support/tracking-advanced
+
+        auto: true,
+        // optional, defaults to `true` (automatically track page views)
+
+        canonical: true,
+        // optional, defaults to `true`
+
+        excludedDomains: 'example.com,localhost',
+        // optional, defaults to ''
+
+        honorDoNotTrack: false,
+        // optional, defaults to `false`
+
+        includedDomains: 'example.com,localhost',
+        // optional, defaults to ''
+
+        scriptSrc: 'https://bluedonkey.example.com/script.js',
+        // optional, defaults to 'https://cdn.usefathom.com/tracker.js'
+        // See here for details: https://usefathom.com/support/custom-domains
+
+        spa: 'auto',
+        // optional, defaults to 'auto'
     }],
     // ....
 ]

--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ modules: [
     // ....
     ['@yabhq/nuxt-fathom', {
         siteId: 'XXXXXX', // required
+
+        // Advanced configuration. See here for details: https://usefathom.com/support/tracking-advanced
         spa: 'pushstate' // optional, defaults to pushstate. https://usefathom.com/support/tracking
         scriptSrc: 'https://bluedonkey.example.com/script.js', // optional, defaults to `https://cdn.usefathom.com/tracker.js`. https://usefathom.com/support/custom-domains
+        honorDoNotTrack: false, // optional, defaults to `false`
     }],
     // ....
 ]

--- a/lib/module.js
+++ b/lib/module.js
@@ -22,7 +22,7 @@ function nuxtFathom(options) {
   }
 
   if ( !options.spa ) {
-    options.spa = 'pushstate'
+    options.spa = 'auto'
   }
 
   if ( !options.scriptSrc ) {

--- a/lib/module.js
+++ b/lib/module.js
@@ -9,8 +9,16 @@ function nuxtFathom(options) {
     options.canonical = true
   }
 
+  if ( !options.excludedDomains ) {
+    options.excludedDomains = ''
+  }
+
   if ( typeof options.honorDoNotTrack !== 'boolean' ) {
     options.honorDoNotTrack = false
+  }
+
+  if ( !options.includedDomains ) {
+    options.includedDomains = ''
   }
 
   if ( !options.spa ) {

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,6 +1,10 @@
 const { resolve } = require('path')
 
 function nuxtFathom(options) {
+  if ( typeof options.auto !== 'boolean' ) {
+    options.auto = true
+  }
+
   if ( typeof options.honorDoNotTrack !== 'boolean' ) {
     options.honorDoNotTrack = false
   }

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,6 +1,10 @@
 const { resolve } = require('path')
 
 function nuxtFathom(options) {
+  if ( typeof options.honorDoNotTrack !== 'boolean' ) {
+    options.honorDoNotTrack = false
+  }
+
   if ( !options.spa ) {
     options.spa = 'pushstate'
   }

--- a/lib/module.js
+++ b/lib/module.js
@@ -33,6 +33,7 @@ function nuxtFathom(options) {
   if ( !options.siteId ) {
     return
   }
+
   // Register plugin
   this.addPlugin({
     src: resolve(__dirname, 'plugin.js'),

--- a/lib/module.js
+++ b/lib/module.js
@@ -5,6 +5,10 @@ function nuxtFathom(options) {
     options.auto = true
   }
 
+  if ( typeof options.canonical !== 'boolean' ) {
+    options.canonical = true
+  }
+
   if ( typeof options.honorDoNotTrack !== 'boolean' ) {
     options.honorDoNotTrack = false
   }

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,17 +1,22 @@
 const { resolve } = require('path')
 
 function nuxtFathom(options) {
-  // Disable if siteId missing
   if ( !options.spa ) {
     options.spa = 'pushstate'
   }
+
+  if ( !options.scriptSrc ) {
+    options.scriptSrc = 'https://cdn.usefathom.com/tracker.js'
+  }
+
+  // Disable if siteId missing
   if ( !options.siteId ) {
     return
   }
   // Register plugin
   this.addPlugin({
     src: resolve(__dirname, 'plugin.js'),
-    fileName: "fathom.js",
+    fileName: 'fathom.js',
     options,
     ssr: false
   })

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -5,11 +5,11 @@
       ;(a[h].q = a[h].q || []).push(arguments)
     }
   ;(o = f.createElement('script')), (m = f.getElementsByTagName('script')[0])
-  o.async = 1
+  o.defer = true
   o.src = t
   o.id = 'fathom-script'
+  o.setAttribute('site', '<%= options.siteId %>')
+  o.setAttribute('spa', '<%= options.spa %>')
   m.parentNode.insertBefore(o, m)
 })(document, window, '<%= options.scriptSrc %>', 'fathom')
-fathom('set', 'spa', '<%= options.spa %>')
-fathom('set', 'siteId', '<%= options.siteId %>')
 fathom('trackPageview')

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -9,7 +9,7 @@
   o.src = t
   o.id = 'fathom-script'
   m.parentNode.insertBefore(o, m)
-})(document, window, 'https://cdn.usefathom.com/tracker.js', 'fathom')
+})(document, window, '<%= options.scriptSrc %>', 'fathom')
 fathom('set', 'spa', '<%= options.spa %>')
 fathom('set', 'siteId', '<%= options.siteId %>')
 fathom('trackPageview')

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -10,7 +10,9 @@
   o.id = 'fathom-script'
   o.setAttribute('auto', <%= options.auto %>)
   o.setAttribute('canonical', <%= options.canonical %>)
+  o.setAttribute('excluded-domains', '<%= options.excludedDomains %>')
   o.setAttribute('honor-dnt', <%= options.honorDoNotTrack %>)
+  o.setAttribute('included-domains', '<%= options.includedDomains %>')
   o.setAttribute('site', '<%= options.siteId %>')
   o.setAttribute('spa', '<%= options.spa %>')
   m.parentNode.insertBefore(o, m)

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -8,9 +8,9 @@
   o.defer = true
   o.src = t
   o.id = 'fathom-script'
+  o.setAttribute('auto', <%= options.auto %>)
   o.setAttribute('honor-dnt', <%= options.honorDoNotTrack %>)
   o.setAttribute('site', '<%= options.siteId %>')
   o.setAttribute('spa', '<%= options.spa %>')
   m.parentNode.insertBefore(o, m)
 })(document, window, '<%= options.scriptSrc %>', 'fathom')
-fathom('trackPageview')

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -9,6 +9,7 @@
   o.src = t
   o.id = 'fathom-script'
   o.setAttribute('auto', <%= options.auto %>)
+  o.setAttribute('canonical', <%= options.canonical %>)
   o.setAttribute('honor-dnt', <%= options.honorDoNotTrack %>)
   o.setAttribute('site', '<%= options.siteId %>')
   o.setAttribute('spa', '<%= options.spa %>')

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -8,6 +8,7 @@
   o.defer = true
   o.src = t
   o.id = 'fathom-script'
+  o.setAttribute('honor-dnt', <%= options.honorDoNotTrack %>)
   o.setAttribute('site', '<%= options.siteId %>')
   o.setAttribute('spa', '<%= options.spa %>')
   m.parentNode.insertBefore(o, m)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@yabhq/nuxt-fathom",
+  "version": "1.1.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yabhq/nuxt-fathom",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "NuxtJS module for Fathom Analytics",
   "main": "lib/module.js",
   "directories": {
@@ -15,11 +15,8 @@
   },
   "keywords": [
     "fathom",
-    "fathom",
     "analytics",
     "nuxt-fathom",
-    "nuxt",
-    "fathom",
     "nuxt",
     "nuxtjs",
     "vue",


### PR DESCRIPTION
It looks like Fathom Analytics [updated its tracking script](https://usefathom.com/blog/custom-domains-embed-code) – setting the `siteId` wasn't working for me. I took the time to update this module to support the new script and also added [some more options](https://usefathom.com/support/tracking-advanced), as well as support for the [new custom domain feature](https://usefathom.com/support/custom-domains).

I left untouched what didn't need changing, but maybe we could add linting, etc. to further improve this module.